### PR TITLE
Add chpharos-exec for single shot commands through specified version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION=0.1.0
 AUTHOR=kontena
 URL=https://github.com/kontena/chpharos
 
-DIRS=share
+DIRS=share bin
 INSTALL_DIRS=`find $(DIRS) -type d 2>/dev/null`
 INSTALL_FILES=`find $(DIRS) -type f 2>/dev/null`
 

--- a/bin/chpharos-exec
+++ b/bin/chpharos-exec
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+chpharos_sh="${0%/*}/../share/chpharos/chpharos.sh"
+
+source "$chpharos_sh"
+
+case "$1" in
+	-h|--help)
+		echo "usage: chpharos-exec PHAROS_VERSION -- COMMAND [ARGS...]"
+		exit
+		;;
+	-V|--version)
+		echo "chpharos-exec $CHPHAROS_VERSION"
+		exit
+		;;
+esac
+
+if (( $# == 0 )); then
+	echo "chpharos-exec: PHAROS_VERSION and COMMAND required" >&2
+	exit 1
+fi
+
+chpharos_version="$1"
+shift
+
+if (( $# == 0)); then
+  echo "chpharos-exec: COMMAND required" >&2
+  exit 1
+fi
+
+shell_opts=("-l")
+[[ -t 0 ]] && shell_opts+=("-i")
+
+source_command="command -v chpharos >/dev/null || source $chpharos_sh"
+chpharos_command="chpharos use ${chpharos_version} > /dev/null"
+command="$source_command; $chpharos_command && exec $@"
+
+exec "$SHELL" -c "$command"

--- a/test/test
+++ b/test/test
@@ -128,6 +128,21 @@ testChpharosReset() {
   assertFalse "path does not include $check_path" "[[ \"$PATH\" == *\"$check_path\"* ]]"
 }
 
+testChpharosExec() {
+  oPATH="${PATH}"
+  PATH="$CHPHAROS_BIN:$PATH"
+  assertEquals "chpharos-exec ${CHPHAROS_VERSION}" "$(chpharos-exec --version)"
+  version=$(chpharos-exec 1.0.0 pharos-cluster version | grep "pharos-cluster version")
+  assertEquals "pharos-cluster version 1.0.0" "${version}"
+  version=$(chpharos-exec 1.0.0 kubectl version --short --client)
+  assertEquals "Client Version: v1.10.1" "${version}"
+  version=$(chpharos-exec 1.2.2 pharos-cluster version | grep "pharos-cluster version")
+  assertEquals "  - pharos-cluster version 1.2.2" "${version}"
+  version=$(chpharos-exec 1.2.2 kubectl version --short --client)
+  assertEquals "Client Version: v1.10.5" "${version}"
+  PATH="${oPATH}"
+}
+
 [ ! -z "${ZSH_VERSION}" ] && SHUNIT_PARENT=$0 && setopt shwordsplit
 
 test_root=`dirname "${BASH_SOURCE[0]-$0}"`
@@ -135,6 +150,7 @@ test_root=`cd "$test_root" && pwd`
 
 export CHPHAROS_ROOT="${test_root}/test-binaries"
 export CHPHAROS_SRC="${test_root}/../share/chpharos/chpharos.sh"
+export CHPHAROS_BIN="${test_root}/../bin"
 
 echo "CHPHAROS_ROOT=${CHPHAROS_ROOT}"
 echo "CHPHAROS_SRC=${CHPHAROS_SRC}"


### PR DESCRIPTION
Add a bin-file for executing commands through specified version of pharos bundle.

```console
$ chpharos-exec 1.2.2 pharos-cluster version
$ chpharos-exec 1.2.2 kubectl version
```

