### PR TITLE
Undefine any previously defined chpharos functions on load

### DIFF
--- a/share/chpharos/chpharos.sh
+++ b/share/chpharos/chpharos.sh
@@ -192,6 +192,13 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+if command -v compgen &> /dev/null; then
+  for chpharos_function in $(compgen -A function | grep _chpharos_); do
+    unset -f "${chpharos_function}"
+  done
+  unset chpharos_function
+fi
+
 CHPHAROS_VERSION=0.2.3
 
 _chpharos_error_echo() {


### PR DESCRIPTION
Tries to find all `_chpharos_*` functions and undefine them in the beginning of the script.

Mostly relevant when developing chpharos or upgrading without restarting the shell.
