### PR TITLE
Fix subcommand lookup when using a non-english locale

### DIFF
--- a/share/chpharos/chpharos.sh
+++ b/share/chpharos/chpharos.sh
@@ -828,7 +828,7 @@ chpharos() {
     subcommand="_chpharos_subcommand_$1"
     subcommand="${subcommand//_--/_longdash_}"
     subcommand="${subcommand//-/_}"
-    if type "${subcommand}" | grep -q 'function'; then
+    if declare -Ff "${subcommand}" &> /dev/null; then
       shift
       "${subcommand}" "$@"
     else


### PR DESCRIPTION
Fixes #29

Chpharos failed to find subcommands when using a shells with non-english locale settings.

This is because something like `type "_chpharos_subcommand_login"` responds with something like "on funktio" or "ist eine funktion" and grepping for `is a function` fails to find a match.

Replaced with `declare -FF "_chpharos_subcommand_login" &> /dev/null` which seems to work both in bash and zsh.
