### PR TITLE
Allow chpharos-exec to install missing versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,30 @@ You can use `chpharos use --local 1.1.1` to create a `.pharos-version` file in t
 1. Download the [bash-completion.sh](https://raw.githubusercontent.com/kontena/chpharos/master/opt/bash-completion.sh)
 2. Place the file into the completion configuration directory on your machine or add a line to your shell's start-up configuration file (`.bash_profile`, `.zshrc`, ..) to load it: `source <path-to-bash-completion.sh>`
 
-## About Kontena Pharos
+### Usage in scripts or CI/CD pipelines
+
+You can use the `chpharos-exec` command to execute specified versions of pharos without sourcing the chpharos first:
+
+```
+$ chpharos-exec 1.3.2 pharos --version
+pharos-cluster 1.3.2
+$ chpharos-exec 1.3.2 kubectl version --short --client
+Client Version: v1.9.3
+```
+
+You can make `chpharos-exec` install the requested version automatically if it was not already installed. This is useful in CI/CD pipeline deployment scripts.
+Add your Kontena Account token to `CHPHAROS_TOKEN` secret/environment variable and use `chpharos-exec -i` in your script:
+
+```
+curl -s https://get.pharos.sh | bash && chpharos-exec -i 1.3.2 pharos up
+```
+
+It's also possible to just run the installation:
+
+```
+chpharos-exec -i 1.3.2
+```
+
 
 [Kontena Pharos](https://pharos.sh) is a simple, solid and certified [Kubernetes](https://kubernetes.io/) distribution that just works. It is composed of the latest upstream Kubernetes with all the essential components delivering a robust foundation that works at any scale. It is open source under Apache 2 license and free for any purpose: personal or commercial.
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ It's also possible to just run the installation:
 chpharos-exec -i 1.3.2
 ```
 
+## About Kontena Pharos
 
 [Kontena Pharos](https://pharos.sh) is a simple, solid and certified [Kubernetes](https://kubernetes.io/) distribution that just works. It is composed of the latest upstream Kubernetes with all the essential components delivering a robust foundation that works at any scale. It is open source under Apache 2 license and free for any purpose: personal or commercial.
 
@@ -154,4 +155,4 @@ Slack: [Join the Kontena Community Slack channel](https://slack.kontena.io/).
 
 ## License
 
-Kontena chpharos is licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for full license text.
+Kontena chpharos is licensed under the Apache 2 License, Version 2.0. See [LICENSE](LICENSE) for full license text.

--- a/bin/chpharos-exec
+++ b/bin/chpharos-exec
@@ -4,28 +4,58 @@ chpharos_sh="${0%/*}/../share/chpharos/chpharos.sh"
 
 source "$chpharos_sh"
 
+install=""
+
 case "$1" in
-	-h|--help)
-		echo "usage: chpharos-exec PHAROS_VERSION -- COMMAND [ARGS...]"
-		exit
-		;;
-	-V|--version)
-		echo "chpharos-exec $CHPHAROS_VERSION"
-		exit
-		;;
+  -h|--help)
+    echo "usage: chpharos-exec [OPTIONS] PHAROS_VERSION -- COMMAND [ARGS...]"
+    echo ""
+    echo "options:"
+    echo " -i | --install   install requested pharos version before executing the command if it isn't installed yet"
+    echo " -V | --version   display chpharos-exec/chphaors version"
+    echo " -h | --help      display help"
+    echo ""
+    echo "When using the automatic installation feature, make sure you have performed a chpharos login first"
+    echo "or have your Kontena Account token in the CHPHAROS_TOKEN environment variable."
+    exit
+    ;;
+  -i)
+    install="true"
+    shift
+    ;;
+  -V|--version)
+    echo "chpharos-exec $CHPHAROS_VERSION"
+    exit
+    ;;
 esac
 
 if (( $# == 0 )); then
-	echo "chpharos-exec: PHAROS_VERSION and COMMAND required" >&2
-	exit 1
+  echo "chpharos-exec: PHAROS_VERSION and COMMAND required" >&2
+  exit 1
 fi
 
 chpharos_version="$1"
 shift
 
+if ! _chpharos_version_is_installed "${chpharos_version}"; then
+  if [ ! -z "${install}" ]; then
+    if ! _chpharos_subcommand_install "${chpharos_version}"; then
+      echo "chpharos-exec: installation of version ${chpharos_version} failed" >&2
+      exit 1
+    fi
+  else
+    echo "chpharos-exec: version ${chpharos_version} is not installed. use chpharos-exec -i PHAROS_VERSION -- COMMAND [ARGS...] to automatically install before running COMMAND" >&2
+    exit 1
+  fi
+fi
+
 if (( $# == 0)); then
-  echo "chpharos-exec: COMMAND required" >&2
-  exit 1
+  if [ -z "${install}" ]; then
+    echo "chpharos-exec: COMMAND required" >&2
+    exit 1
+  else
+    exit
+  fi
 fi
 
 shell_opts=("-l")


### PR DESCRIPTION
`chpharos-exec` can now automatically install the requested pharos version if not yet installed:

```
$ chpharos-exec 1.3.2 pharos --help
chpharos-exec: version 1.3.2 is not installed. use chpharos-exec -i PHAROS_VERSION -- COMMAND [ARGS...] to automatically install before running COMMAND
```

==> 

```
$ chpharos-exec -i 1.3.2 pharos --help
Downloading 'pharos-cluster' (16000792 bytes) from https://get.pharos.sh/versions/download/pharos-cluster-darwin-amd64-1.3.2 ..
######################################################################## 100.0%
Verifying download SHA256 checksum.. OK
Downloading 'kubectl' (54938928 bytes) from https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/darwin/amd64/kubectl ..
######################################################################## 100.0%
Verifying download SHA256 checksum.. OK
Installed version 1.3.2. To set as current, use: chpharos use 1.3.2
Usage:
    pharos-cluster [OPTIONS] SUBCOMMAND [ARG] ...

  pharos-cluster - Kontena Pharos cluster manager

Parameters:
...
```

This is useful in CI/CD pipelines. 

The chpharos itself is a shell function and cumbersome to use in CI scripts, you have to do something like `bash -c "source /xyz/chpharos.sh; chpharos install 1.3.2 && chpharos use 1.3.2 && pharos up"`. 

Directly downloading the binaries is also cumbersome.

The `chpharos-exec` is an executable, so you can just do: `curl -s https://get.pharos.sh | bash && chpharos-exec -i 1.3.2 pharos up` (you need to have `CHPHAROS_TOKEN` environment variable set)
